### PR TITLE
Base classes and decorators

### DIFF
--- a/aiohttp_json_api/encoder.py
+++ b/aiohttp_json_api/encoder.py
@@ -1,0 +1,15 @@
+import functools
+import json
+
+from .jsonpointer import JSONPointer
+
+
+class JSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, JSONPointer):
+            return o.path
+        else:
+            return super(JSONEncoder, self).default(o)
+
+
+json_dumps = functools.partial(json.dumps, cls=JSONEncoder)

--- a/aiohttp_json_api/errors.py
+++ b/aiohttp_json_api/errors.py
@@ -5,7 +5,7 @@ Errors
 import json
 from http import HTTPStatus
 
-import inflection
+from .encoder import json_dumps
 
 __all__ = (
     'Error',
@@ -99,7 +99,7 @@ class Error(Exception):
         """
         Returns the :attr:`detail` attribute per default.
         """
-        return json.dumps(self.json, indent=4, sort_keys=True)
+        return json_dumps(self.json, indent=4, sort_keys=True)
 
     @property
     def json(self):

--- a/aiohttp_json_api/errors.py
+++ b/aiohttp_json_api/errors.py
@@ -121,8 +121,7 @@ class Error(Exception):
         if self.source_pointer or self.source_parameter:
             d['source'] = dict()
             if self.source_pointer:
-                d['source']['pointer'] = \
-                    inflection.dasherize(self.source_pointer.path)
+                d['source']['pointer'] = self.source_pointer
             if self.source_parameter:
                 d['source']['parameter'] = self.source_parameter
         if self.meta:

--- a/aiohttp_json_api/handlers.py
+++ b/aiohttp_json_api/handlers.py
@@ -196,9 +196,8 @@ async def get_relationship(request: web.Request):
 
     resource = await schema.query_resource(id_=resource_id, context=context)
     relation = await relation_field.query(schema, resource, context)
-    result = await schema.encode_relationship(
-        relation_name, relation, pagination=pagination
-    )
+    result = schema.serialize_relationship(relation_name, relation,
+                                           pagination=pagination)
     return jsonapi_response(result)
 
 
@@ -237,9 +236,8 @@ async def post_relationship(request: web.Request):
         data=data,
         sp=JSONPointer('')
     )
-    result = await schema.encode_relationship(
-        relation_name, resource, pagination=pagination
-    )
+    result = schema.serialize_relationship(relation_name, resource,
+                                           pagination=pagination)
     return jsonapi_response(result)
 
 
@@ -278,9 +276,8 @@ async def patch_relationship(request: web.Request):
         sp=JSONPointer('')
     )
 
-    result = await schema.encode_relationship(
-        relation_name, resource, pagination=pagination
-    )
+    result = schema.serialize_relationship(relation_name, resource,
+                                           pagination=pagination)
     return jsonapi_response(result)
 
 

--- a/aiohttp_json_api/handlers.py
+++ b/aiohttp_json_api/handlers.py
@@ -109,7 +109,7 @@ async def get_resource(request: web.Request):
         raise HTTPNotFound()
 
     resource_id = request.match_info.get('id')
-    await validate_uri_resource_id(schema, resource_id, context)
+    validate_uri_resource_id(schema, resource_id, context)
 
     resource = await schema.query_resource(id_=resource_id, context=context)
 
@@ -137,7 +137,7 @@ async def patch_resource(request: web.Request):
         raise HTTPNotFound()
 
     resource_id = request.match_info.get('id')
-    await validate_uri_resource_id(schema, resource_id, context)
+    validate_uri_resource_id(schema, resource_id, context)
 
     data = await get_data_from_request(request)
     if not isinstance(data, collections.Mapping):
@@ -168,7 +168,7 @@ async def delete_resource(request: web.Request):
         raise HTTPNotFound()
 
     resource_id = request.match_info.get('id')
-    await validate_uri_resource_id(schema, resource_id, context)
+    validate_uri_resource_id(schema, resource_id, context)
 
     await schema.delete_resource(resource=resource_id, context=context)
     return web.HTTPNoContent()
@@ -186,7 +186,7 @@ async def get_relationship(request: web.Request):
     )
 
     resource_id = request.match_info.get('id')
-    await validate_uri_resource_id(schema, resource_id, context)
+    validate_uri_resource_id(schema, resource_id, context)
 
     pagination = None
     if relation_field.to_many:
@@ -222,7 +222,7 @@ async def post_relationship(request: web.Request):
     pagination = None
 
     resource_id = request.match_info.get('id')
-    await validate_uri_resource_id(schema, resource_id, context)
+    validate_uri_resource_id(schema, resource_id, context)
 
     if relation_field.to_many:
         pagination_type = relation_field.pagination
@@ -262,7 +262,7 @@ async def patch_relationship(request: web.Request):
     )
 
     resource_id = request.match_info.get('id')
-    await validate_uri_resource_id(schema, resource_id, context)
+    validate_uri_resource_id(schema, resource_id, context)
 
     pagination = None
     if relation_field.to_many:
@@ -299,7 +299,7 @@ async def delete_relationship(request: web.Request):
     relation_name = request.match_info['relation']
 
     resource_id = request.match_info.get('id')
-    await validate_uri_resource_id(schema, resource_id, context)
+    validate_uri_resource_id(schema, resource_id, context)
 
     data = await get_data_from_request(request)
     await schema.remove_relationship(
@@ -332,7 +332,7 @@ async def get_related(request: web.Request):
     pagination = None
 
     resource_id = request.match_info.get('id')
-    await validate_uri_resource_id(schema, resource_id, context)
+    validate_uri_resource_id(schema, resource_id, context)
 
     if relation_field.to_many:
         pagination_type = relation_field.pagination

--- a/aiohttp_json_api/helpers.py
+++ b/aiohttp_json_api/helpers.py
@@ -31,3 +31,11 @@ def is_collection(obj):
     e.g list, tuple, queryset.
     """
     return is_iterable_but_not_string(obj) and not isinstance(obj, Mapping)
+
+
+def is_instance_or_subclass(val, class_):
+    """Return True if ``val`` is either a subclass or instance of ``class_``."""
+    try:
+        return issubclass(val, class_)
+    except TypeError:
+        return isinstance(val, class_)

--- a/aiohttp_json_api/pagination.py
+++ b/aiohttp_json_api/pagination.py
@@ -72,7 +72,7 @@ class BasePagination:
         and if so, a new pagination instance with these parameters is returned
         and *None* otherwise.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     @property
     def url(self) -> yarl.URL:
@@ -108,7 +108,7 @@ class BasePagination:
         *   *next*
             The link to the next page (only set, if a next page exists)
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def page_link(self, **kwargs) -> str:
         """

--- a/aiohttp_json_api/schema/abc.py
+++ b/aiohttp_json_api/schema/abc.py
@@ -1,17 +1,5 @@
 class FieldABC(object):
-    def setter(self, f):
-        raise NotImplementedError
-
     def validator(self, f, step, on):
-        raise NotImplementedError
-
-    async def default_set(self, schema, resource, data, sp, **kwargs):
-        raise NotImplementedError
-
-    async def get(self, schema, resource, **kwargs):
-        raise NotImplementedError
-
-    async def set(self, schema, resource, data, sp, **kwargs):
         raise NotImplementedError
 
     def encode(self, schema, data, **kwargs):

--- a/aiohttp_json_api/schema/abc.py
+++ b/aiohttp_json_api/schema/abc.py
@@ -1,7 +1,4 @@
-class FieldABC(object):
-    def validator(self, f, step, on):
-        raise NotImplementedError
-
+class FieldABC:
     def encode(self, schema, data, **kwargs):
         raise NotImplementedError
 
@@ -23,7 +20,31 @@ class SchemaABC(object):
     opts = None
     inflect = None
 
+    def default_getter(self, field, resource, **kwargs):
+        raise NotImplementedError
+
+    def default_setter(self, field, resource, data, sp, **kwargs):
+        raise NotImplementedError
+
+    async def default_include(self, field, resources, context, **kwargs):
+        raise NotImplementedError
+
+    async def default_query(self, field, resource, context, **kwargs):
+        raise NotImplementedError
+
+    async def default_add(self, field, resource, data, sp):
+        raise NotImplementedError
+
+    async def default_remove(self, field, resource, data, sp):
+        raise NotImplementedError
+
     def get_relationship_field(self, relation_name, source_parameter=None):
+        raise NotImplementedError
+
+    def get_value(self, field, resource, **kwargs):
+        raise NotImplementedError
+
+    def set_value(self, field, resource, data, sp, **kwargs):
         raise NotImplementedError
 
     def serialize_resource(self, resource, **kwargs):
@@ -32,14 +53,16 @@ class SchemaABC(object):
     def serialize_relationship(self, relation_name, resource, *, pagination=None):
         raise NotImplementedError
 
-    def validate_resource_pre_decode(self, data, sp, context, *,
-                                     expected_id=None):
+    def validate_resource_before_deserialization(self, data, sp, context, *,
+                                                 expected_id=None):
         raise NotImplementedError
 
-    def deserialize_resource(self, data, sp):
+    def validate_resource_after_deserialization(self, memo, context):
         raise NotImplementedError
 
-    def validate_resource_post_decode(self, memo, context):
+    def deserialize_resource(self, data, sp, *, context=None,
+                             expected_id=None, validate=True,
+                             validation_steps=()):
         raise NotImplementedError
 
     async def create_resource(self, data, sp, context, **kwargs):

--- a/aiohttp_json_api/schema/abc.py
+++ b/aiohttp_json_api/schema/abc.py
@@ -1,14 +1,8 @@
 class FieldABC(object):
-    def getter(self, f):
-        raise NotImplementedError
-
     def setter(self, f):
         raise NotImplementedError
 
     def validator(self, f, step, on):
-        raise NotImplementedError
-
-    async def default_get(self, schema, resource, **kwargs):
         raise NotImplementedError
 
     async def default_set(self, schema, resource, data, sp, **kwargs):
@@ -44,17 +38,17 @@ class SchemaABC(object):
     def get_relationship_field(self, relation_name, source_parameter=None):
         raise NotImplementedError
 
-    async def encode_resource(self, resource, **kwargs):
+    def serialize_resource(self, resource, **kwargs):
         raise NotImplementedError
 
-    def encode_relationship(self, relation_name, resource, *, pagination=None):
+    def serialize_relationship(self, relation_name, resource, *, pagination=None):
         raise NotImplementedError
 
     def validate_resource_pre_decode(self, data, sp, context, *,
                                      expected_id=None):
         raise NotImplementedError
 
-    def decode_resource(self, data, sp):
+    def deserialize_resource(self, data, sp):
         raise NotImplementedError
 
     def validate_resource_post_decode(self, memo, context):

--- a/aiohttp_json_api/schema/abc.py
+++ b/aiohttp_json_api/schema/abc.py
@@ -1,0 +1,98 @@
+class FieldABC(object):
+    def getter(self, f):
+        raise NotImplementedError
+
+    def setter(self, f):
+        raise NotImplementedError
+
+    def validator(self, f, step, on):
+        raise NotImplementedError
+
+    async def default_get(self, schema, resource, **kwargs):
+        raise NotImplementedError
+
+    async def default_set(self, schema, resource, data, sp, **kwargs):
+        raise NotImplementedError
+
+    async def get(self, schema, resource, **kwargs):
+        raise NotImplementedError
+
+    async def set(self, schema, resource, data, sp, **kwargs):
+        raise NotImplementedError
+
+    def encode(self, schema, data, **kwargs):
+        raise NotImplementedError
+
+    def decode(self, schema, data, sp, **kwargs):
+        raise NotImplementedError
+
+    def pre_validate(self, schema, data, sp, context):
+        raise NotImplementedError
+
+    def post_validate(self, schema, data, sp, context):
+        raise NotImplementedError
+
+
+class SchemaABC(object):
+    #: The JSON API *type*. (Leave it empty to derive it automatic from the
+    #: resource class name or the schema name).
+    type = None
+    resource_class = None
+    opts = None
+    inflect = None
+
+    def get_relationship_field(self, relation_name, source_parameter=None):
+        raise NotImplementedError
+
+    async def encode_resource(self, resource, **kwargs):
+        raise NotImplementedError
+
+    def encode_relationship(self, relation_name, resource, *, pagination=None):
+        raise NotImplementedError
+
+    def validate_resource_pre_decode(self, data, sp, context, *,
+                                     expected_id=None):
+        raise NotImplementedError
+
+    def decode_resource(self, data, sp):
+        raise NotImplementedError
+
+    def validate_resource_post_decode(self, memo, context):
+        raise NotImplementedError
+
+    async def create_resource(self, data, sp, context, **kwargs):
+        raise NotImplementedError
+
+    async def update_resource(self, resource, data, sp, context, **kwargs):
+        raise NotImplementedError
+
+    async def delete_resource(self, resource, context, **kwargs):
+        raise NotImplementedError
+
+    async def update_relationship(self, relation_name, resource,
+                                  data, sp, context, **kwargs):
+        raise NotImplementedError
+
+    async def add_relationship(self, relation_name, resource,
+                               data, sp, context, **kwargs):
+        raise NotImplementedError
+
+    async def remove_relationship(self, relation_name, resource,
+                                  data, sp, context, **kwargs):
+        raise NotImplementedError
+
+    async def query_collection(self, context, **kwargs):
+        raise NotImplementedError
+
+    async def query_resource(self, resource_id, context, **kwargs):
+        raise NotImplementedError
+
+    async def query_relative(self, relation_name, resource, context, **kwargs):
+        raise NotImplementedError
+
+    async def query_relatives(self, relation_name, resource, context, **kwargs):
+        raise NotImplementedError
+
+    async def fetch_include(self, relation_name, resources, context, *,
+                            rest_path=None, **kwargs):
+        raise NotImplementedError

--- a/aiohttp_json_api/schema/abc.py
+++ b/aiohttp_json_api/schema/abc.py
@@ -93,6 +93,6 @@ class SchemaABC(object):
     async def query_relatives(self, relation_name, resource, context, **kwargs):
         raise NotImplementedError
 
-    async def fetch_include(self, relation_name, resources, context, *,
-                            rest_path=None, **kwargs):
+    async def fetch_compound_documents(self, relation_name, resources, context,
+                                       *, rest_path=None, **kwargs):
         raise NotImplementedError

--- a/aiohttp_json_api/schema/base_fields.py
+++ b/aiohttp_json_api/schema/base_fields.py
@@ -106,8 +106,7 @@ class BaseField(FieldABC):
 
     def __init__(self, *, name: str = '', mapped_key: str = '',
                  writable: Event = Event.ALWAYS,
-                 required: Event = Event.NEVER,
-                 fset: Coroutine = None):
+                 required: Event = Event.NEVER):
         #: The name of this field on the
         # :class:`~aiohttp_json_api.schema.Schema`
         #: it has been defined on. Please note, that not each field has a *key*
@@ -128,17 +127,7 @@ class BaseField(FieldABC):
         assert isinstance(required, Event)
         self.required = required
 
-        self.fset = fset
         self.fvalidators = list()
-
-    def setter(self, f):
-        """
-        Descriptor to change the setter.
-
-        :seealso: :func:`aiohttp_json_api.schema.decorators.sets`
-        """
-        self.fset = f
-        return self
 
     def validator(self, f: Callable,
                   step: Step = Step.POST_DECODE,
@@ -158,27 +147,6 @@ class BaseField(FieldABC):
             'validator': f, 'step': step, 'on': on
         })
         return self
-
-    async def default_set(self, schema, resource, data, sp, **kwargs):
-        """Used if no *setter* has been defined. Can be overridden."""
-        if self.mapped_key:
-            setattr(resource, self.mapped_key, data)
-        return None
-
-    async def set(self, schema, resource, data, sp, **kwargs):
-        """
-        Changes the value of the field on the resource.
-
-        :arg ~aiohttp_json_api.schema.Schema schema:
-            The schema this field has been defined on.
-        :arg data:
-            The (decoded and validated) new value of the field
-        :arg ~aiohttp_json_api.jsonpointer.JSONPointer sp:
-            A JSON pointer to the source of the original input data.
-        """
-        assert self.writable is not Event.NEVER
-        f = self.fset or self.default_set
-        return await f(schema, resource, data, sp, **kwargs)
 
     def encode(self, schema, data, **kwargs):
         """

--- a/aiohttp_json_api/schema/base_fields.py
+++ b/aiohttp_json_api/schema/base_fields.py
@@ -59,6 +59,7 @@ You should only work with the following fields directly:
 from collections import Coroutine, Callable, Mapping
 from typing import Sequence
 
+from .abc import FieldABC
 from .common import Event, Step
 from ..errors import InvalidType, InvalidValue
 
@@ -71,7 +72,7 @@ __all__ = (
 )
 
 
-class BaseField(object):
+class BaseField(FieldABC):
     """
     This class describes the base for all fields defined on a schema and
     knows how to encode, decode and update the field. A field is usually
@@ -229,7 +230,7 @@ class BaseField(object):
         """
         return data
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         """
         Validates the raw JSON API input for this field. This method is
         called before :meth:`decode`.
@@ -250,7 +251,7 @@ class BaseField(object):
             f = validator['validator']
             f(schema, data, sp)
 
-    def validate_post_decode(self, schema, data, sp, context):
+    def post_validate(self, schema, data, sp, context):
         """
         Validates the decoded input *data* for this field. This method is
         called after :meth:`decode`.
@@ -593,6 +594,6 @@ class Relationship(BaseField, LinksObjectMixin):
             detail = 'The "data" member is required.'
             raise InvalidValue(detail=detail, source_pointer=sp)
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         self.validate_relationship_object(schema, data, sp)
-        super(Relationship, self).validate_pre_decode(schema, data, sp, context)
+        super(Relationship, self).pre_validate(schema, data, sp, context)

--- a/aiohttp_json_api/schema/base_fields.py
+++ b/aiohttp_json_api/schema/base_fields.py
@@ -379,7 +379,6 @@ class Relationship(BaseField):
     def __init__(self, *, dereference: bool = True,
                  require_data: Event = Event.ALWAYS,
                  foreign_types: Sequence[str] = None,
-                 fquery: Coroutine = None,
                  links: Sequence[Link] = None,
                  **kwargs):
         BaseField.__init__(self, **kwargs)
@@ -390,7 +389,6 @@ class Relationship(BaseField):
         self.dereference = dereference
 
         self.foreign_types = frozenset(foreign_types or [])
-        self.fquery = fquery
 
         assert isinstance(require_data, Event)
         self.require_data = require_data
@@ -407,21 +405,6 @@ class Relationship(BaseField):
         """
         self.links[link.name] = link
         return self
-
-    def query_(self, f: Coroutine):
-        """
-        Descriptor to change the query function.
-
-        :seealso: :func:`~aiohttp_json_api.schema.decorators.queries`
-        """
-        self.fquery = f
-        return self
-
-    async def default_query(self, schema, resource, context, **kwargs):
-        """Used of no *query* function has been defined. Can be overridden."""
-        if self.mapped_key:
-            return getattr(resource, self.mapped_key)
-        raise RuntimeError('No query method and mapped_key have been defined.')
 
     async def query(self, schema, resource, context, **kwargs):
         """Queries the related resources."""

--- a/aiohttp_json_api/schema/base_fields.py
+++ b/aiohttp_json_api/schema/base_fields.py
@@ -212,7 +212,7 @@ class BaseField(FieldABC):
         :arg ~aiohttp_json_api.jsonpointer.JSONPointer sp:
             A JSON pointer to the source of the original input data.
         """
-        assert self.writable not in Event.NEVER
+        assert self.writable is not Event.NEVER
         f = self.fset or self.default_set
         return await f(schema, resource, data, sp, **kwargs)
 

--- a/aiohttp_json_api/schema/common.py
+++ b/aiohttp_json_api/schema/common.py
@@ -10,10 +10,10 @@ else:
 
 
 class Step(Enum):
-    PRE_DECODE = auto()
-    POST_DECODE = auto()
-    PRE_ENCODE = auto()
-    POST_ENCODE = auto()
+    BEFORE_DESERIALIZATION = auto()
+    AFTER_DESERIALIZATION = auto()
+    BEFORE_SERIALIZATION = auto()
+    AFTER_SERIALIZATION = auto()
 
 
 class Event(Flag):

--- a/aiohttp_json_api/schema/decorators.py
+++ b/aiohttp_json_api/schema/decorators.py
@@ -89,7 +89,7 @@ def tag_processor(tag, fn, **kwargs):
     except AttributeError:
         fn.__processing_kwargs__ = processing_kwargs = {}
 
-    field_key = kwargs.get('field_key')
+    field_key = kwargs.pop('field_key', None)
     processing_tags.add((tag, field_key))
     processing_kwargs[(tag, field_key)] = kwargs
 

--- a/aiohttp_json_api/schema/decorators.py
+++ b/aiohttp_json_api/schema/decorators.py
@@ -142,7 +142,7 @@ updates = sets
 
 
 def validates(field_key,
-              step: Step = Step.POST_DECODE, on: Event = Event.ALWAYS):
+              step: Step = Step.AFTER_DESERIALIZATION, on: Event = Event.ALWAYS):
     """
     Decorator for adding a validator::
 

--- a/aiohttp_json_api/schema/fields.py
+++ b/aiohttp_json_api/schema/fields.py
@@ -33,7 +33,6 @@ from the standard library.
 import collections
 import datetime
 import fractions
-import typing
 import uuid
 from enum import Enum
 

--- a/aiohttp_json_api/schema/fields.py
+++ b/aiohttp_json_api/schema/fields.py
@@ -81,13 +81,13 @@ class String(Attribute):
         if self.allow_none:
             self._trafaret = self._trafaret | t.Null()
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         try:
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidValue(detail=error.as_dict(), source_pointer=sp)
-        return super(String, self).validate_pre_decode(schema, data, sp,
-                                                       context)
+        return super(String, self).pre_validate(schema, data, sp,
+                                                context)
 
     def encode(self, schema, data, **kwargs):
         result = self._trafaret.converter(data)
@@ -103,12 +103,12 @@ class Integer(Attribute):
         if self.allow_none:
             self._trafaret = self._trafaret | t.Null()
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         try:
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidValue(detail=error.as_dict(), source_pointer=sp)
-        return super().validate_pre_decode(schema, data, sp, context)
+        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return self._trafaret.check(data)
@@ -124,12 +124,12 @@ class Float(Attribute):
         if self.allow_none:
             self._trafaret = self._trafaret | t.Null()
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         try:
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidValue(detail=error.as_dict(), source_pointer=sp)
-        return super().validate_pre_decode(schema, data, sp, context)
+        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return self._trafaret.check(data)
@@ -146,7 +146,7 @@ class Complex(Attribute):
         {"real": 1.2, "imag": 42}
     """
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         detail = "Must be an object with a 'real' and 'imag' member.'"
 
         if not isinstance(data, collections.Mapping):
@@ -164,7 +164,7 @@ class Complex(Attribute):
         if not isinstance(data["imag"], (int, float)):
             detail = "The imaginar part must be a number."
             raise InvalidValue(detail=detail, source_pointer=sp / "imag")
-        return super().validate_pre_decode(schema, data, sp, context)
+        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return complex(data["real"], data["imag"])
@@ -182,12 +182,12 @@ class Decimal(Attribute):
         if self.allow_none:
             self._trafaret = self._trafaret | t.Null()
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         try:
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidValue(detail=error.as_dict(), source_pointer=sp)
-        return super().validate_pre_decode(schema, data, sp, context)
+        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return self._trafaret.check(data)
@@ -218,7 +218,7 @@ class Fraction(Attribute):
         self.min = min
         self.max = max
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         if not isinstance(data, dict):
             detail = "Must be an object with a 'numerator' and 'denominator' " \
                      "member."
@@ -247,7 +247,7 @@ class Fraction(Attribute):
         if self.max is not None and self.max < val:
             detail = "Must be <= {}.".format(self.max)
             raise InvalidValue(detail=detail, source_pointer=sp)
-        return super().validate_pre_decode(schema, data, sp, context)
+        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return fractions.Fraction(int(data[0]), int(data[1]))
@@ -267,12 +267,12 @@ class DateTime(Attribute):
         if self.allow_none:
             self._trafaret = self._trafaret | t.Null()
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         try:
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidValue(detail=error.as_dict(), source_pointer=sp)
-        return super().validate_pre_decode(schema, data, sp, context)
+        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return self._trafaret.check(data)
@@ -303,7 +303,7 @@ class TimeDelta(Attribute):
         self.min = min
         self.max = max
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         try:
             data = float(data)
         except TypeError:
@@ -317,7 +317,7 @@ class TimeDelta(Attribute):
             raise InvalidValue(detail=detail, source_pointer=sp)
         if self.max is not None and self.max < data:
             detail = "The timedelta must be <= {}.".format(self.max)
-        return super().validate_pre_decode(schema, data, sp, context)
+        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return datetime.timedelta(seconds=float(data))
@@ -337,7 +337,7 @@ class UUID(Attribute):
         super(UUID, self).__init__(**kwargs)
         self.version = version
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         if not isinstance(data, str):
             detail = "The UUID must be a hexadecimal string."
             raise InvalidType(detail=detail, source_pointer=sp)
@@ -352,7 +352,7 @@ class UUID(Attribute):
         if self.version is not None and self.version != data.version:
             detail = "Not a UUID{}.".format(self.version)
             raise InvalidValue(detail=detail, source_pointer=sp)
-        return super().validate_pre_decode(schema, data, sp, context)
+        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return uuid.UUID(hex=data)
@@ -371,12 +371,12 @@ class Boolean(Attribute):
         if self.allow_none:
             self._trafaret = self._trafaret | t.Null()
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         try:
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidType(detail=error.as_dict(), source_pointer=sp)
-        return super().validate_pre_decode(schema, data, sp, context)
+        return super().pre_validate(schema, data, sp, context)
 
     def encode(self, schema, data, **kwargs):
         return self._trafaret.check(data)
@@ -385,7 +385,7 @@ class Boolean(Attribute):
 class URI(Attribute):
     """Parses the URI with :func:`rfc3986.urlparse` and returns the result."""
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         if not isinstance(data, str):
             detail = "Must be a string."
             raise InvalidType(detail=detail, source_pointer=sp)
@@ -394,7 +394,7 @@ class URI(Attribute):
         except ValueError:
             detail = "Not a valid URI."
             raise InvalidValue(detail=detail, source_pointer=sp)
-        return super().validate_pre_decode(schema, data, sp, context)
+        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return URL(data)
@@ -411,7 +411,7 @@ class Email(Attribute):
         if self.allow_none:
             self._trafaret = self._trafaret | t.Null()
 
-    def validate_pre_decode(self, schema, data, sp, context):
+    def pre_validate(self, schema, data, sp, context):
         try:
             self._trafaret.check(data)
         except t.DataError:
@@ -421,7 +421,7 @@ class Email(Attribute):
             else:
                 detail = "Not a valid Email address."
                 raise InvalidValue(detail=detail, source_pointer=sp)
-        return super().validate_pre_decode(schema, data, sp, context)
+        return super().pre_validate(schema, data, sp, context)
 
     def encode(self, schema, data, **kwargs):
         return self._trafaret.check(data)

--- a/aiohttp_json_api/schema/fields.py
+++ b/aiohttp_json_api/schema/fields.py
@@ -86,8 +86,6 @@ class String(Attribute):
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidValue(detail=error.as_dict(), source_pointer=sp)
-        return super(String, self).pre_validate(schema, data, sp,
-                                                context)
 
     def encode(self, schema, data, **kwargs):
         result = self._trafaret.converter(data)
@@ -108,7 +106,6 @@ class Integer(Attribute):
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidValue(detail=error.as_dict(), source_pointer=sp)
-        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return self._trafaret.check(data)
@@ -129,7 +126,6 @@ class Float(Attribute):
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidValue(detail=error.as_dict(), source_pointer=sp)
-        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return self._trafaret.check(data)
@@ -164,7 +160,6 @@ class Complex(Attribute):
         if not isinstance(data["imag"], (int, float)):
             detail = "The imaginar part must be a number."
             raise InvalidValue(detail=detail, source_pointer=sp / "imag")
-        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return complex(data["real"], data["imag"])
@@ -187,7 +182,6 @@ class Decimal(Attribute):
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidValue(detail=error.as_dict(), source_pointer=sp)
-        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return self._trafaret.check(data)
@@ -220,8 +214,8 @@ class Fraction(Attribute):
 
     def pre_validate(self, schema, data, sp, context):
         if not isinstance(data, dict):
-            detail = "Must be an object with a 'numerator' and 'denominator' " \
-                     "member."
+            detail = "Must be an object with " \
+                     "a 'numerator' and 'denominator' member."
             raise InvalidType(detail=detail, source_pointer=sp)
         if not "numerator" in data:
             detail = "Does not have a 'numerator' member."
@@ -247,7 +241,6 @@ class Fraction(Attribute):
         if self.max is not None and self.max < val:
             detail = "Must be <= {}.".format(self.max)
             raise InvalidValue(detail=detail, source_pointer=sp)
-        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return fractions.Fraction(int(data[0]), int(data[1]))
@@ -272,7 +265,6 @@ class DateTime(Attribute):
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidValue(detail=error.as_dict(), source_pointer=sp)
-        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return self._trafaret.check(data)
@@ -317,7 +309,7 @@ class TimeDelta(Attribute):
             raise InvalidValue(detail=detail, source_pointer=sp)
         if self.max is not None and self.max < data:
             detail = "The timedelta must be <= {}.".format(self.max)
-        return super().pre_validate(schema, data, sp, context)
+            raise InvalidValue(detail=detail, source_pointer=sp)
 
     def decode(self, schema, data, sp, **kwargs):
         return datetime.timedelta(seconds=float(data))
@@ -332,7 +324,6 @@ class UUID(Attribute):
     :arg int version:
         The required version of the UUID.
     """
-
     def __init__(self, *, version=None, **kwargs):
         super(UUID, self).__init__(**kwargs)
         self.version = version
@@ -352,7 +343,6 @@ class UUID(Attribute):
         if self.version is not None and self.version != data.version:
             detail = "Not a UUID{}.".format(self.version)
             raise InvalidValue(detail=detail, source_pointer=sp)
-        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return uuid.UUID(hex=data)
@@ -376,7 +366,6 @@ class Boolean(Attribute):
             self._trafaret.check(data)
         except t.DataError as error:
             raise InvalidType(detail=error.as_dict(), source_pointer=sp)
-        return super().pre_validate(schema, data, sp, context)
 
     def encode(self, schema, data, **kwargs):
         return self._trafaret.check(data)
@@ -394,7 +383,6 @@ class URI(Attribute):
         except ValueError:
             detail = "Not a valid URI."
             raise InvalidValue(detail=detail, source_pointer=sp)
-        return super().pre_validate(schema, data, sp, context)
 
     def decode(self, schema, data, sp, **kwargs):
         return URL(data)
@@ -421,7 +409,6 @@ class Email(Attribute):
             else:
                 detail = "Not a valid Email address."
                 raise InvalidValue(detail=detail, source_pointer=sp)
-        return super().pre_validate(schema, data, sp, context)
 
     def encode(self, schema, data, **kwargs):
         return self._trafaret.check(data)

--- a/aiohttp_json_api/schema/fields.py
+++ b/aiohttp_json_api/schema/fields.py
@@ -490,8 +490,8 @@ class List(Attribute):
 
     def decode(self, schema, data, sp, **kwargs):
         return [
-            self.field.decode(schema, item, sp / i) for item, i in
-            enumerate(data)
+            self.field.decode(schema, item, sp / i)
+            for item, i in enumerate(data)
         ]
 
     def encode(self, schema, data, **kwargs):

--- a/aiohttp_json_api/schema/relationships.py
+++ b/aiohttp_json_api/schema/relationships.py
@@ -41,7 +41,7 @@ class ToOne(Relationship):
 
     def encode(self, schema, data, **kwargs) -> typing.MutableMapping:
         """Composes the final relationships object."""
-        document = {'links': {}}
+        document = {'links': kwargs.get('links', {})}
 
         if data is None:
             document['data'] = data
@@ -53,10 +53,6 @@ class ToOne(Relationship):
         else:
             document['data'] = \
                 schema.registry.ensure_identifier(data, asdict=True)
-
-        links = kwargs.get('links', {})
-        if links:
-            document['links'].update(links)
 
         return filter_empty_fields(document)
 
@@ -155,17 +151,13 @@ class ToMany(Relationship):
             If not *None*, the links and meta members of the pagination
             helper are added to the final JSON API relationship object.
         """
-        document = {'links': {}, 'meta': {}}
+        document = {'links': kwargs.get('links', {}), 'meta': {}}
 
         if isinstance(data, collections.Iterable):
             document['data'] = [
                 schema.registry.ensure_identifier(item, asdict=True)
                 for item in data
             ]
-
-        links = kwargs.get('links', {})
-        if links:
-            document['links'].update(links)
 
         pagination = kwargs.get('pagination')
         if pagination:

--- a/aiohttp_json_api/schema/relationships.py
+++ b/aiohttp_json_api/schema/relationships.py
@@ -42,12 +42,7 @@ class ToOne(Relationship):
 
     def encode(self, schema, data, **kwargs) -> typing.MutableMapping:
         """Composes the final relationships object."""
-        document = {
-            'links': {
-                link.name: link.encode(schema, data, **kwargs)
-                for link in self.links.values()
-            }
-        }
+        document = {'links': kwargs.get('links', {})}
 
         if data is None:
             document['data'] = data
@@ -158,10 +153,7 @@ class ToMany(Relationship):
             helper are added to the final JSON API relationship object.
         """
         document = {
-            'links': {
-                link.name: link.encode(schema, data, **kwargs)
-                for link in self.links.values()
-            },
+            'links': kwargs.get('links', {}),
             'meta': {}
         }
 

--- a/aiohttp_json_api/schema/relationships.py
+++ b/aiohttp_json_api/schema/relationships.py
@@ -38,7 +38,6 @@ class ToOne(Relationship):
         super(ToOne, self).validate_relationship_object(schema, data, sp)
         if 'data' in data and data['data'] is not None:
             self.validate_resource_identifier(schema, data['data'], sp / 'data')
-        return None
 
     def encode(self, schema, data, **kwargs) -> typing.MutableMapping:
         """Composes the final relationships object."""
@@ -85,65 +84,9 @@ class ToMany(Relationship):
     to_one = False
     to_many = True
 
-    def __init__(self, *, fadd=None, fremove=None, pagination=None, **kwargs):
+    def __init__(self, *, pagination=None, **kwargs):
         super(ToMany, self).__init__(**kwargs)
-        self.fadd = fadd
-        self.fremove = fremove
         self.pagination = pagination
-
-    def adder(self, f):
-        """
-        Descriptor to change the adder.
-
-        :seealso: :func:`~aiohttp_json_api.schema.decorators.adds`
-        """
-        self.fadd = f
-        return self
-
-    def remover(self, f):
-        """
-        Descriptor to change the remover.
-
-        :seealso: :func:`~aiohttp_json_api.schema.decorators.removes`
-        """
-        self.fremove = f
-        return self
-
-    async def default_add(self, schema, resource, data, sp):
-        """Used if no *adder* has been defined. **Should** be overridden."""
-        logger.warning('You should override the adder.')
-
-        if not self.mapped_key:
-            raise RuntimeError('No adder and mapped_key have been defined.')
-
-        relatives = getattr(resource, self.mapped_key)
-        relatives.extend(data)
-        return None
-
-    async def default_remove(self, schema, resource, data, sp):
-        """Used if not *remover* has been defined. **Should** be overridden."""
-        logger.warning('You should override the remover.')
-
-        if not self.mapped_key:
-            raise RuntimeError('No remover and mapped_key have been defined.')
-
-        relatives = getattr(resource, self.mapped_key)
-        for relative in data:
-            try:
-                relatives.remove(relative)
-            except ValueError:
-                pass
-        return None
-
-    async def add(self, schema, resource, data, sp, **kwargs):
-        """Adds new resources to the relationship."""
-        f = self.fadd or self.default_add
-        return await f(schema, resource, data, sp, **kwargs)
-
-    async def remove(self, schema, resource, data, sp, **kwargs):
-        """Removes resources from the relationship."""
-        f = self.fremove or self.default_remove
-        return await f(schema, resource, data, sp, **kwargs)
 
     def encode(self, schema, data, **kwargs) -> typing.MutableMapping:
         """Composes the final JSON API relationships object.

--- a/aiohttp_json_api/schema/schema.py
+++ b/aiohttp_json_api/schema/schema.py
@@ -944,8 +944,8 @@ class Schema(abc.SchemaABC, metaclass=SchemaMeta):
         relatives = await field.query(self, resource, context, **kwargs)
         return relatives
 
-    async def fetch_include(self, relation_name, resources, context, *,
-                            rest_path=None, **kwargs):
+    async def fetch_compound_documents(self, relation_name, resources, context,
+                                       *, rest_path=None, **kwargs):
         """
         .. seealso::
 
@@ -955,10 +955,12 @@ class Schema(abc.SchemaABC, metaclass=SchemaMeta):
         :meth:`~aiohttp_json_api.schema.base_fields.Relationship.include`
         method of the *Relationship* fields. **Can be overridden.**
 
-        :arg resources:
-            A list of resources.
         :arg str relation_name:
             The name of the relationship.
+        :arg resources:
+            A list of resources.
+        :arg RequestContext context:
+            Request context instance.
         :arg list rest_path:
             The name of the relationships of the returned relatives, which
             will also be included.

--- a/aiohttp_json_api/schema/schema.py
+++ b/aiohttp_json_api/schema/schema.py
@@ -700,7 +700,7 @@ class Schema(metaclass=SchemaMeta):
         :arg resource:
             The id of the resource or the resource instance
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     # CRUD (relationships)
     # --------------------
@@ -727,7 +727,6 @@ class Schema(metaclass=SchemaMeta):
 
         self._validate_field_pre_decode(field, data, sp, context)
         decoded = self._decode_field(field, data, sp)
-        # self._validate_field_post_decode(field, data, sp, context)
 
         if not isinstance(resource, self.resource_class):
             resource = await self.query_resource(resource, context, **kwargs)
@@ -759,7 +758,6 @@ class Schema(metaclass=SchemaMeta):
 
         self._validate_field_pre_decode(field, data, sp, context)
         decoded = self._decode_field(field, data, sp)
-        # self._validate_field_post_decode(field, data, sp, context)
 
         if not isinstance(resource, self.resource_class):
             resource = await self.query_resource(resource, context, **kwargs)
@@ -791,7 +789,6 @@ class Schema(metaclass=SchemaMeta):
 
         self._validate_field_pre_decode(field, data, sp, context)
         decoded = self._decode_field(field, data, sp)
-        # self._validate_field_post_decode(field, data, sp, context)
 
         if not isinstance(resource, self.resource_class):
             resource = await self.query_resource(resource, context, **kwargs)
@@ -813,7 +810,7 @@ class Schema(metaclass=SchemaMeta):
         :arg ~aiohttp_json_api.context.RequestContext context:
             Request context object.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     async def query_resource(self, id_, context, **kwargs):
         """
@@ -831,7 +828,7 @@ class Schema(metaclass=SchemaMeta):
         :raises ~aiohttp_json_api.errors.ResourceNotFound:
             If there is no resource with the given *id_*.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     async def query_relative(self, relation_name, resource, context, **kwargs):
         """

--- a/aiohttp_json_api/schema/schema.py
+++ b/aiohttp_json_api/schema/schema.py
@@ -406,7 +406,7 @@ class Schema(abc.SchemaABC, metaclass=SchemaMeta):
 
     def _get_processors(self, tag: Tag, field: BaseField,
                         default: typing.Union[typing.Callable,
-                                              typing.Coroutine] = None):
+                                              typing.Coroutine]):
         if self._has_processors:
             processor_tag = tag, field.key
             processors = self.__processors__.get(processor_tag)
@@ -421,14 +421,14 @@ class Schema(abc.SchemaABC, metaclass=SchemaMeta):
 
     def get_value(self, field, resource, **kwargs):
         getter, getter_kwargs = first(
-            self._get_processors(Tag.GET, field, default=self.default_getter)
+            self._get_processors(Tag.GET, field, self.default_getter)
         )
         return getter(field, resource, **getter_kwargs, **kwargs)
 
     def set_value(self, field, resource, data, sp, **kwargs):
         assert field.writable is not Event.NEVER
         setter, setter_kwargs = first(
-            self._get_processors(Tag.SET, field, default=self.default_setter)
+            self._get_processors(Tag.SET, field, self.default_setter)
         )
         return setter(field, resource, data, sp, **setter_kwargs, **kwargs)
 
@@ -839,7 +839,7 @@ class Schema(abc.SchemaABC, metaclass=SchemaMeta):
             resource = await self.query_resource(resource, context, **kwargs)
 
         adder, adder_kwargs = first(
-            self._get_processors(Tag.ADD, field, default=self.default_add)
+            self._get_processors(Tag.ADD, field, self.default_add)
         )
         await adder(field, resource, decoded, sp,
                     context=context, **adder_kwargs, **kwargs)
@@ -874,8 +874,7 @@ class Schema(abc.SchemaABC, metaclass=SchemaMeta):
             resource = await self.query_resource(resource, context, **kwargs)
 
         remover, remover_kwargs = first(
-            self._get_processors(Tag.REMOVE, field,
-                                 default=self.default_remove)
+            self._get_processors(Tag.REMOVE, field, self.default_remove)
         )
         await remover(field, resource, decoded, sp,
                       context=context, **remover_kwargs, **kwargs)
@@ -933,7 +932,7 @@ class Schema(abc.SchemaABC, metaclass=SchemaMeta):
         field = self.get_relationship_field(relation_name)
 
         query, query_kwargs = first(
-            self._get_processors(Tag.QUERY, field, default=self.default_query)
+            self._get_processors(Tag.QUERY, field, self.default_query)
         )
         return await query(field, resource, context, **query_kwargs, **kwargs)
 
@@ -967,8 +966,7 @@ class Schema(abc.SchemaABC, metaclass=SchemaMeta):
         field = self.get_relationship_field(relation_name,
                                             source_parameter='include')
         include, include_kwargs = first(
-            self._get_processors(Tag.INCLUDE, field,
-                                 default=self.default_include)
+            self._get_processors(Tag.INCLUDE, field, self.default_include)
         )
         return await include(field, resources, context,
                              **include_kwargs, **kwargs)

--- a/aiohttp_json_api/schema/schema.py
+++ b/aiohttp_json_api/schema/schema.py
@@ -443,8 +443,7 @@ class Schema(metaclass=SchemaMeta):
             raise InvalidValue(detail=detail, source_pointer=sp)
 
         if sp is not None:
-            field.validate_pre_decode(self, data, sp, context)
-        return None
+            field.pre_validate(self, data, sp, context)
 
     def validate_resource_pre_decode(self, data, sp, context, *,
                                      expected_id=""):

--- a/aiohttp_json_api/schema/schema.py
+++ b/aiohttp_json_api/schema/schema.py
@@ -445,8 +445,14 @@ class Schema(abc.SchemaABC, metaclass=SchemaMeta):
             for field in fields.values():
                 if fieldset is None or field.name in fieldset:
                     field_data = self.get_value(field, resource, **kwargs)
-                    result[key][field.name] = field.encode(self, field_data,
-                                                           **kwargs)
+                    links = None
+                    if isinstance(field, Relationship):
+                        links = {
+                            link.name: link.encode(self, resource, **kwargs)
+                            for link in field.links.values()
+                        }
+                    result[key][field.name] = \
+                        field.encode(self, field_data, links=links, **kwargs)
 
             # Filter out empty keys
             if not result.get(key):

--- a/aiohttp_json_api/utils.py
+++ b/aiohttp_json_api/utils.py
@@ -180,7 +180,7 @@ def error_to_response(request: web.Request,
     )
 
 
-async def validate_uri_resource_id(schema, resource_id, context):
+def validate_uri_resource_id(schema, resource_id, context):
     field = schema._id
     if field:
         try:

--- a/aiohttp_json_api/utils.py
+++ b/aiohttp_json_api/utils.py
@@ -78,9 +78,9 @@ async def get_compound_documents(resources, context, **kwargs):
         if relation_name in relationships[schema.type]:
             return
 
-        relatives = await schema.fetch_include(relation_name,
-                                               collection, context,
-                                               rest_path=rest_path, **kwargs)
+        relatives = await schema.fetch_compound_documents(
+            relation_name, collection, context, rest_path=rest_path, **kwargs
+        )
 
         if any(relatives):
             for relative in relatives:

--- a/aiohttp_json_api/utils.py
+++ b/aiohttp_json_api/utils.py
@@ -13,20 +13,12 @@ from aiohttp import web
 from boltons.iterutils import remap, first
 from boltons.typeutils import make_sentinel
 
-from .jsonpointer import JSONPointer
-from .helpers import is_collection
 from .const import JSONAPI, JSONAPI_CONTENT_TYPE
+from .helpers import is_collection
+from .encoder import json_dumps
 from .errors import Error, ErrorList, ValidationError
 
 SENTINEL = make_sentinel()
-
-
-class JSONEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, JSONPointer):
-            return o.path
-        else:
-            return super(JSONEncoder, self).default(o)
 
 
 def filter_empty_fields(data: typing.MutableMapping) -> typing.MutableMapping:
@@ -43,7 +35,7 @@ def jsonapi_response(data=SENTINEL, *, text=None, body=None,
                      reason=None, headers=None,
                      dumps=None):
     if not callable(dumps):
-        dumps = functools.partial(json.dumps, cls=JSONEncoder)
+        dumps = json_dumps
 
     return web.json_response(
         data=data, text=text, body=body, status=status,

--- a/aiohttp_json_api/utils.py
+++ b/aiohttp_json_api/utils.py
@@ -186,8 +186,8 @@ async def validate_uri_resource_id(schema, resource_id, context):
     field = schema._id
     if field:
         try:
-            field.validate_pre_decode(schema, resource_id,
-                                      sp=None, context=context)
+            field.pre_validate(schema, resource_id,
+                               sp=None, context=context)
         except ValidationError as e:
             e.source_parameter = 'id'
             raise e

--- a/aiohttp_json_api/utils.py
+++ b/aiohttp_json_api/utils.py
@@ -101,9 +101,7 @@ async def get_compound_documents(resources, context, **kwargs):
 async def encode_resource(resource, context):
     registry = context.request.app[JSONAPI]['registry']
     schema = registry.get_schema(resource)
-    return await schema.encode_resource(
-        resource, is_data=True, context=context,
-    )
+    return await schema.encode_resource(resource, context=context)
 
 
 async def render_document(resources, compound_documents, context, *,

--- a/aiohttp_json_api/utils.py
+++ b/aiohttp_json_api/utils.py
@@ -2,6 +2,7 @@
 Utilities
 =========
 """
+import functools
 import json
 import typing
 from collections import OrderedDict, defaultdict
@@ -12,11 +13,20 @@ from aiohttp import web
 from boltons.iterutils import remap, first
 from boltons.typeutils import make_sentinel
 
+from .jsonpointer import JSONPointer
 from .helpers import is_collection
 from .const import JSONAPI, JSONAPI_CONTENT_TYPE
 from .errors import Error, ErrorList, ValidationError
 
 SENTINEL = make_sentinel()
+
+
+class JSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, JSONPointer):
+            return o.path
+        else:
+            return super(JSONEncoder, self).default(o)
 
 
 def filter_empty_fields(data: typing.MutableMapping) -> typing.MutableMapping:
@@ -31,7 +41,10 @@ def filter_empty_fields(data: typing.MutableMapping) -> typing.MutableMapping:
 def jsonapi_response(data=SENTINEL, *, text=None, body=None,
                      status=web.HTTPOk.status_code,
                      reason=None, headers=None,
-                     dumps=json.dumps):
+                     dumps=None):
+    if not callable(dumps):
+        dumps = functools.partial(json.dumps, cls=JSONEncoder)
+
     return web.json_response(
         data=data, text=text, body=body, status=status,
         reason=reason, headers=headers, content_type=JSONAPI_CONTENT_TYPE,


### PR DESCRIPTION
Mass refactoring of schema, fields, validation and decorators.
Generic approach to setup Schema decorators is used (inspired by Marshmallow).
Fields are used only for encode/decode now (with pre/post validation). Additional validators for fields must be created on schema level.
Custom JSON encoder with support JSONPointer serialization.