### PR TITLE
Generalize handlers calls

### DIFF
--- a/aiohttp_json_api/context.py
+++ b/aiohttp_json_api/context.py
@@ -28,8 +28,9 @@ class SortDirection(Enum):
 
 
 class RequestContext:
-    def __init__(self, request: web.Request):
+    def __init__(self, request: web.Request, resource_type: str = None):
         self._pagination = None
+        self._resource_type = resource_type
         self.request = request
         self.filters = self.parse_request_filters(request)
         self.fields = self.parse_request_fields(request)
@@ -43,7 +44,7 @@ class RequestContext:
     @property
     def schema(self) -> Optional[Schema]:
         registry = self.request.app[JSONAPI]['registry']
-        return registry.get(self.request.match_info.get('type'), None)
+        return registry.get(self._resource_type, None)
 
     @property
     def pagination(self):

--- a/aiohttp_json_api/middleware.py
+++ b/aiohttp_json_api/middleware.py
@@ -11,14 +11,6 @@ from .utils import error_to_response
 async def jsonapi_middleware(app, handler):
     async def middleware_handler(request):
         try:
-            route_name = request.match_info.route.name
-            if route_name and route_name.startswith('jsonapi'):
-                context_class = app[JSONAPI]['context_class']
-                context = context_class(request)
-                request[JSONAPI] = context
-                if context.schema is None:
-                    logger.warning('No schema for request %s', request.url)
-
             return await handler(request)
         except Exception as exc:
             if isinstance(exc, (Error, ErrorList)):


### PR DESCRIPTION
- Customisable JSON API handlers support
- DRY in handlers
- Move context builder from middleware to `jsonapi_handler` decorator
- Request context receive optional `resource_type` now