### PR TITLE
Loosen accept header check

### DIFF
--- a/aiohttp_json_api/common.py
+++ b/aiohttp_json_api/common.py
@@ -19,6 +19,7 @@ JSONAPI = 'jsonapi'
 
 #: JSON API Content-Type by specification
 JSONAPI_CONTENT_TYPE = 'application/vnd.api+json'
+ALL_CONTENT_TYPES = '*/*'
 
 #: Regular expression rule for check allowed fields and types names
 ALLOWED_MEMBER_NAME_RULE = \

--- a/aiohttp_json_api/middleware.py
+++ b/aiohttp_json_api/middleware.py
@@ -29,7 +29,7 @@ async def jsonapi_middleware(app, handler):
                     request_ct != JSONAPI_CONTENT_TYPE):
                     raise HTTPUnsupportedMediaType(detail=content_type_error)
 
-                request_accept = request.headers.get(hdrs.ACCEPT, '*/*').split(',')
+                request_accept = request.headers.get(hdrs.ACCEPT, ALL_CONTENT_TYPES).split(',')
                 if not any(accept_ct == JSONAPI_CONTENT_TYPE or
                            accept_ct.split(';', 1)[0] == ALL_CONTENT_TYPES
                            for accept_ct in request_accept):

--- a/aiohttp_json_api/middleware.py
+++ b/aiohttp_json_api/middleware.py
@@ -1,7 +1,7 @@
 """Middleware."""
 from aiohttp import hdrs
 
-from .common import JSONAPI, JSONAPI_CONTENT_TYPE, logger
+from .common import JSONAPI, JSONAPI_CONTENT_TYPE, ALL_CONTENT_TYPES, logger
 from .errors import (
     Error, ErrorList, HTTPUnsupportedMediaType, HTTPNotAcceptable
 )
@@ -29,9 +29,10 @@ async def jsonapi_middleware(app, handler):
                     request_ct != JSONAPI_CONTENT_TYPE):
                     raise HTTPUnsupportedMediaType(detail=content_type_error)
 
-                request_accept = request.headers.get(hdrs.ACCEPT, '*/*')
-                if (request_accept != '*/*' and
-                    request_accept != JSONAPI_CONTENT_TYPE):
+                request_accept = request.headers.get(hdrs.ACCEPT, '*/*').split(',')
+                if not any(accept_ct == JSONAPI_CONTENT_TYPE or
+                           accept_ct.split(';', 1)[0] == ALL_CONTENT_TYPES
+                           for accept_ct in request_accept):
                     raise HTTPNotAcceptable()
 
             return await handler(request)


### PR DESCRIPTION
Allow to sent requests with `Accept` header that contains more than one media types as long as it contains `application/vnd.api+json` or `*/*` media type. 

Also allow to use `*/*` media type with parameters which is required for proper `OPTIONS` requests handling is some cases. 

For example, Firefox generates `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8` `Accept` header for that kind of requests.